### PR TITLE
Use case-insensitive filter when listing repos

### DIFF
--- a/ruby/scripts/list.rb
+++ b/ruby/scripts/list.rb
@@ -5,7 +5,7 @@ require 'github_tools'
 
 Config.validate!
 client = Config.make_client
-org = Config.fetch :github_org
+org = Config.fetch(:github_org).strip
 
 kind = ARGV[0]         # Kind of thing to list. Must be 'repos' (for now)
 first_flag = ARGV[1]   # Must be --all | --subscribed | --topic
@@ -21,7 +21,7 @@ end
 
 repos = case first_flag
         when '--subscribed'
-          client.subscriptions.select { |repo| repo.owner.login == org }
+          client.subscriptions.select { |repo| repo.owner.login.strip.casecmp? org }
         when '--all', '--topic'
           GitHubTools.org_repos topic, org, client
         else


### PR DESCRIPTION
I just tried out the `list` command with `--subscribed` and was getting 0 results, which wasn’t right.

Turned out I had set the env var GITHUB_ORG to `fundingcircle` but the actual value as returned by the GitHub API is `FundingCircle`. This is just annoying so let’s change the filter to use a case-insensitive comparison.